### PR TITLE
enhanced with plume level entrainment feedbacks

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3156,6 +3156,9 @@ if ($clubb_sgs  =~ /$TRUE/io) {
    add_default($nl, 'do_clubb_mf_mixd');
    add_default($nl, 'clubb_mf_up_ndt');
    add_default($nl, 'clubb_mf_cp_ndt');
+   add_default($nl, 'do_clubb_mf_lscale_perplume');
+   add_default($nl, 'do_clubb_mf_coldpool_perplume');
+   add_default($nl, 'do_clubb_mf_coldpool_init');
 }
 
 # Force exit if running cam_dev and CLUBB is off

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3156,6 +3156,7 @@ if ($clubb_sgs  =~ /$TRUE/io) {
    add_default($nl, 'do_clubb_mf_mixd');
    add_default($nl, 'clubb_mf_up_ndt');
    add_default($nl, 'clubb_mf_cp_ndt');
+   add_default($nl, 'clubb_mf_kseed');
    add_default($nl, 'do_clubb_mf_lscale_perplume');
    add_default($nl, 'do_clubb_mf_coldpool_perplume');
    add_default($nl, 'do_clubb_mf_coldpool_init');

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1966,7 +1966,7 @@
 <do_clubb_mf_mixd                  > .false. </do_clubb_mf_mixd>
 <clubb_mf_up_ndt                   > 1       </clubb_mf_up_ndt>
 <clubb_mf_cp_ndt                   > 1       </clubb_mf_cp_ndt>
-
+<clubb_mf_kseed                    > 1       </clubb_mf_kseed>
 
 <!-- Microphysics scheme -->
 <micro_mg_do_hail                       > .false. </micro_mg_do_hail>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1953,8 +1953,11 @@
 <clubb_mf_b0                       > 0.5     </clubb_mf_b0>
 <clubb_mf_nup                      > 10      </clubb_mf_nup>
 <clubb_mf_max_L0                   > 10.e3   </clubb_mf_max_L0>
+<do_clubb_mf_lscale_perplume       > .false. </do_clubb_mf_lscale_perplume>
 <clubb_mf_fdd                      > 0.0     </clubb_mf_fdd>
 <do_clubb_mf_coldpool              > .false. </do_clubb_mf_coldpool>
+<do_clubb_mf_coldpool_init         > .false. </do_clubb_mf_coldpool_init>
+<do_clubb_mf_coldpool_perplume     > .false. </do_clubb_mf_coldpool_perplume>
 <clubb_mf_ddalph                   > 2.e2    </clubb_mf_ddalph>
 <clubb_mf_ddbeta                   > 1.0     </clubb_mf_ddbeta>
 <clubb_mf_pwfac                    > 1.0     </clubb_mf_pwfac>
@@ -1963,6 +1966,7 @@
 <do_clubb_mf_mixd                  > .false. </do_clubb_mf_mixd>
 <clubb_mf_up_ndt                   > 1       </clubb_mf_up_ndt>
 <clubb_mf_cp_ndt                   > 1       </clubb_mf_cp_ndt>
+
 
 <!-- Microphysics scheme -->
 <micro_mg_do_hail                       > .false. </micro_mg_do_hail>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -4018,6 +4018,12 @@ Real: number of time-steps for running average of cold pool effects
 Default: 1
 </entry>
 
+<entry id="clubb_mf_kseed" type="integer" category="conv"
+       group="clubb_mf_nl" valid_values="" >
+Real: level position of state used to seed the random number generator
+Default: 1
+</entry>
+
 <!-- CARMA Sectional Microphysics -->
 
 <entry id="carma_model" type="char*32" category="carma"

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -3945,6 +3945,12 @@ Real: limiter on entrainmnet length scale + threshold to diable TKE enhanced ent
 Default: 10.e3
 </entry>
 
+<entry id="do_clubb_mf_lscale_perplume" type="logical" category="conv"
+       group="clubb_mf_nl" valid_values="" >
+If .true. set unique entrainment length scale for each plume member
+Default: .false.
+</entry>
+
 <entry id="clubb_mf_fdd" type="real" category="conv"
        group="clubb_mf_nl" valid_values="" >
 Fraction of autoconversion partitioned to downdrafts (zero means no downdrafts)
@@ -3953,6 +3959,18 @@ Default: 0.0
 <entry id="do_clubb_mf_coldpool" type="logical" category="conv"
        group="clubb_mf_nl" valid_values="" >
 If .true. turn on cold pool feedback parameterizations
+Default: .false.
+</entry>
+
+<entry id="do_clubb_mf_coldpool_init" type="logical" category="conv"
+       group="clubb_mf_nl" valid_values="" >
+If .true. let cold pool feedback impact plume intialization
+Default: .false.
+</entry>
+
+<entry id="do_clubb_mf_coldpool_perplume" type="logical" category="conv"
+       group="clubb_mf_nl" valid_values="" >
+If .true. set cold pool feedback to unique to each plume member
 Default: .false.
 </entry>
 

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -485,16 +485,9 @@ module clubb_intr
       call pbuf_add_field('edmf_thlflx_macmic' ,'physpkg',  dtype_r8, (/pcols,pverp*cld_macmic_num_steps/), mf_wpthlp_macmic_idx)
       call pbuf_add_field('edmf_qtflx_macmic'  ,'physpkg',  dtype_r8, (/pcols,pverp*cld_macmic_num_steps/), mf_wprtp_macmic_idx)
       call pbuf_add_field('edmf_thvflx_macmic' ,'physpkg',  dtype_r8, (/pcols,pverp*cld_macmic_num_steps/), mf_wpthvp_macmic_idx)
-!+++ARH
-      !call pbuf_add_field('ZTOPMN'             ,'global' ,  dtype_r8, (/clubb_mf_up_ndt,pcols/), ztopmn_idx)
-      !call pbuf_add_field('ZTOPMA'             ,'global' ,  dtype_r8, (/pcols/), ztopma_idx)
-      !call pbuf_add_field('ZTOP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols/), ztopm1_macmic_idx)
       call pbuf_add_field('ZTOPMN'             ,'global' ,  dtype_r8, (/clubb_mf_up_ndt,pcols,clubb_mf_nup/), ztopmn_idx)
       call pbuf_add_field('ZTOPMA'             ,'global' ,  dtype_r8, (/pcols,clubb_mf_nup/), ztopma_idx)
       call pbuf_add_field('ZTOP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols,clubb_mf_nup/), ztopm1_macmic_idx)
-      !call pbuf_add_field('DDCP'               ,'global' ,  dtype_r8, (/pcols/), ddcp_idx)
-      !call pbuf_add_field('DDCP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols/), ddcp_macmic_idx)
-      !call pbuf_add_field('DDCPMN'             ,'global' ,  dtype_r8, (/clubb_mf_cp_ndt,pcols/), ddcpmn_idx)
       call pbuf_add_field('DDCP'               ,'global' ,  dtype_r8, (/pcols,clubb_mf_nup/), ddcp_idx)
       call pbuf_add_field('DDCP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols,clubb_mf_nup/), ddcp_macmic_idx)
       call pbuf_add_field('DDCPMN'             ,'global' ,  dtype_r8, (/clubb_mf_cp_ndt,pcols,clubb_mf_nup/), ddcpmn_idx)
@@ -2205,20 +2198,12 @@ end subroutine clubb_init_cnst
    real(r8),pointer :: prec_sh(:)   ! total precipitation from MF
    real(r8),pointer :: snow_sh(:)   ! snow from MF
 
-!+++ARH
-   !real(r8), pointer :: ztopmn(:,:)
-   !real(r8), pointer :: ztopma(:)
-   !real(r8), pointer :: ztopm1_macmic(:)
    real(r8), pointer :: ztopmn(:,:,:)
    real(r8), pointer :: ztopma(:,:)
    real(r8), pointer :: ztopm1_macmic(:,:)
-   !real(r8), pointer :: ddcp(:)
-   !real(r8), pointer :: ddcp_macmic(:)
-   !real(r8), pointer :: ddcpmn(:,:)
    real(r8), pointer :: ddcp(:,:)
    real(r8), pointer :: ddcp_macmic(:,:)
    real(r8), pointer :: ddcpmn(:,:,:)
-!---ARH
 
    real(r8), pointer :: cbm1(:)
    real(r8), pointer :: cbm1_macmic(:)
@@ -2435,13 +2420,9 @@ end subroutine clubb_init_cnst
 
    logical                              :: cfllim
 
-!+++ARH
-   !real(r8)                             :: mf_ztop,    mf_ztop_nadv,   &
-   !                                        mf_ztopm1,  mf_ztopm1_nadv, &
    real(r8)                             :: mf_precc_nadv, mf_snow_nadv,&
-                                           !mf_L0,      mf_L0_nadv,     &
-                                           !mf_ddcp,    mf_ddcp_nadv,   &
                                            mf_cbm1,    mf_cbm1_nadv
+
    real(r8), dimension(clubb_mf_nup)    :: mf_ztop,    mf_ztop_nadv,   &
                                            mf_ztopm1,  mf_ztopm1_nadv, &
                                            mf_L0,      mf_L0_nadv,     &
@@ -3425,16 +3406,8 @@ end subroutine clubb_init_cnst
              thv_ds_zm = zt2zm_api( thv_ds_zt  )
            end if
 
-!+++ARH
-           !mf_ztopm1 = ztopma(i) 
            mf_ztopm1(:) = ztopma(i,:)
-           !mf_ddcp = ddcp(i)
            mf_ddcp(:) = ddcp(i,:)
-write(iam+1000,*) '----------------------------'
-write(iam+1000,*) 'nstep: ', get_nstep(), ' macmic_it: ', macmic_it, ' nadv: ', t
-write(iam+1000,*) 'ztopm1: ', mf_ztopm1(:)
-write(iam+1000,*) 'ddcp: ', mf_ddcp(:)
-!---ARH
            mf_cbm1 = cbm1(i)
 
            rhinv = 0._r8
@@ -3595,12 +3568,10 @@ write(iam+1000,*) 'ddcp: ', mf_ddcp(:)
            max_cfl_nadv = MAX(max_cfl,max_cfl_nadv)
 !+++ARH
          if (t==1) then
-!+++ARH
-           !ztop_macmic1(i,macmic_it) = mf_ztopm1
+
            ztop_macmic1(i,macmic_it) = MAXVAL(mf_ztopm1)
-           !ddcp_macmic1(i,macmic_it) = mf_ddcp
            ddcp_macmic1(i,macmic_it) = MAXVAL(mf_ddcp)
-!---ARH
+
            do k=1,nlev+1
              flip(pverp-k+1,:clubb_mf_nup) = mf_upw(k,:clubb_mf_nup)
            end do
@@ -3703,12 +3674,9 @@ write(iam+1000,*) 'ddcp: ', mf_ddcp(:)
 
          else if (t==2) then
 
-!+++ARH
-           !ztop_macmic2(i,macmic_it) = mf_ztopm1
            ztop_macmic2(i,macmic_it) = MAXVAL(mf_ztopm1)
-           !ddcp_macmic2(i,macmic_it) = mf_ddcp
            ddcp_macmic2(i,macmic_it) = MAXVAL(mf_ddcp)
-!---ARH
+
            do k=1,nlev+1
              flip(pverp-k+1,:clubb_mf_nup) = mf_upw(k,:clubb_mf_nup)
            end do
@@ -3939,14 +3907,6 @@ write(iam+1000,*) 'ddcp: ', mf_ddcp(:)
           if (clubb_mf_up_ndt == 1) then
             ztopma(i,:) = ztopm1_macmic(i,:)/REAL(cld_macmic_num_steps)
           else
-!+++ARH
-            !ztopmn(2:clubb_mf_up_ndt,i) = ztopmn(1:clubb_mf_up_ndt-1,i)
-            !ztopmn(1,i) = ztopm1_macmic(i)/REAL(cld_macmic_num_steps)
-            !ztopma(i) = 0._r8
-            !do t=1,clubb_mf_up_ndt
-            !  ztopma(i) = ztopma(i) + ztopmn(t,i)
-            !end do
-            !ztopma(i) = ztopma(i)/REAL(clubb_mf_up_ndt)
             ztopmn(2:clubb_mf_up_ndt,i,:) = ztopmn(1:clubb_mf_up_ndt-1,i,:)
             ztopmn(1,i,:) = ztopm1_macmic(i,:)/REAL(cld_macmic_num_steps)
             ztopma(i,:) = 0._r8
@@ -3954,20 +3914,11 @@ write(iam+1000,*) 'ddcp: ', mf_ddcp(:)
               ztopma(i,:) = ztopma(i,:) + ztopmn(t,i,:)
             end do
             ztopma(i,:) = ztopma(i,:)/REAL(clubb_mf_up_ndt)
-!---ARH
           end if
 
           if (clubb_mf_cp_ndt == 1) then
             ddcp(i,:) = ddcp_macmic(i,:)/REAL(cld_macmic_num_steps)
           else
-!+++ARH
-            !ddcpmn(2:clubb_mf_cp_ndt,i) = ddcpmn(1:clubb_mf_cp_ndt-1,i)
-            !ddcpmn(1,i) = ddcp_macmic(i)/REAL(cld_macmic_num_steps) 
-            !ddcp(i) = 0._r8
-            !do t=1,clubb_mf_cp_ndt
-            !  ddcp(i) = ddcp(i) + ddcpmn(t,i)
-            !end do
-            !ddcp(i) = ddcp(i)/REAL(clubb_mf_cp_ndt)
             ddcpmn(2:clubb_mf_cp_ndt,i,:) = ddcpmn(1:clubb_mf_cp_ndt-1,i,:)
             ddcpmn(1,i,:) = ddcp_macmic(i,:)/REAL(cld_macmic_num_steps)
             ddcp(i,:) = 0._r8
@@ -3975,7 +3926,6 @@ write(iam+1000,*) 'ddcp: ', mf_ddcp(:)
               ddcp(i,:) = ddcp(i,:) + ddcpmn(t,i,:)
             end do
             ddcp(i,:) = ddcp(i,:)/REAL(clubb_mf_cp_ndt)
-!---ARH
           end if
 
           ddcp(i,:) = clubb_mf_ddalph*ddcp(i,:)

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -485,12 +485,20 @@ module clubb_intr
       call pbuf_add_field('edmf_thlflx_macmic' ,'physpkg',  dtype_r8, (/pcols,pverp*cld_macmic_num_steps/), mf_wpthlp_macmic_idx)
       call pbuf_add_field('edmf_qtflx_macmic'  ,'physpkg',  dtype_r8, (/pcols,pverp*cld_macmic_num_steps/), mf_wprtp_macmic_idx)
       call pbuf_add_field('edmf_thvflx_macmic' ,'physpkg',  dtype_r8, (/pcols,pverp*cld_macmic_num_steps/), mf_wpthvp_macmic_idx)
-      call pbuf_add_field('ZTOPMN'             ,'global' ,  dtype_r8, (/clubb_mf_up_ndt,pcols/), ztopmn_idx)
-      call pbuf_add_field('ZTOPMA'             ,'global' ,  dtype_r8, (/pcols/), ztopma_idx)
-      call pbuf_add_field('ZTOP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols/), ztopm1_macmic_idx)
-      call pbuf_add_field('DDCP'               ,'global' ,  dtype_r8, (/pcols/), ddcp_idx)
-      call pbuf_add_field('DDCP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols/), ddcp_macmic_idx)
-      call pbuf_add_field('DDCPMN'             ,'global' ,  dtype_r8, (/clubb_mf_cp_ndt,pcols/), ddcpmn_idx)
+!+++ARH
+      !call pbuf_add_field('ZTOPMN'             ,'global' ,  dtype_r8, (/clubb_mf_up_ndt,pcols/), ztopmn_idx)
+      !call pbuf_add_field('ZTOPMA'             ,'global' ,  dtype_r8, (/pcols/), ztopma_idx)
+      !call pbuf_add_field('ZTOP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols/), ztopm1_macmic_idx)
+      call pbuf_add_field('ZTOPMN'             ,'global' ,  dtype_r8, (/clubb_mf_up_ndt,pcols,clubb_mf_nup/), ztopmn_idx)
+      call pbuf_add_field('ZTOPMA'             ,'global' ,  dtype_r8, (/pcols,clubb_mf_nup/), ztopma_idx)
+      call pbuf_add_field('ZTOP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols,clubb_mf_nup/), ztopm1_macmic_idx)
+      !call pbuf_add_field('DDCP'               ,'global' ,  dtype_r8, (/pcols/), ddcp_idx)
+      !call pbuf_add_field('DDCP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols/), ddcp_macmic_idx)
+      !call pbuf_add_field('DDCPMN'             ,'global' ,  dtype_r8, (/clubb_mf_cp_ndt,pcols/), ddcpmn_idx)
+      call pbuf_add_field('DDCP'               ,'global' ,  dtype_r8, (/pcols,clubb_mf_nup/), ddcp_idx)
+      call pbuf_add_field('DDCP_MACMIC'        ,'physpkg',  dtype_r8, (/pcols,clubb_mf_nup/), ddcp_macmic_idx)
+      call pbuf_add_field('DDCPMN'             ,'global' ,  dtype_r8, (/clubb_mf_cp_ndt,pcols,clubb_mf_nup/), ddcpmn_idx)
+!---ARH
       call pbuf_add_field('CBM1'               ,'global' ,  dtype_r8, (/pcols/), cbm1_idx)
       call pbuf_add_field('CBM1_MACMIC'        ,'physpkg',  dtype_r8, (/pcols/), cbm1_macmic_idx)
 !+++ARH
@@ -2197,13 +2205,20 @@ end subroutine clubb_init_cnst
    real(r8),pointer :: prec_sh(:)   ! total precipitation from MF
    real(r8),pointer :: snow_sh(:)   ! snow from MF
 
-   real(r8), pointer :: ztopmn(:,:)
-   real(r8), pointer :: ztopma(:)
-   real(r8), pointer :: ztopm1_macmic(:)
-
-   real(r8), pointer :: ddcp(:)
-   real(r8), pointer :: ddcp_macmic(:)
-   real(r8), pointer :: ddcpmn(:,:)
+!+++ARH
+   !real(r8), pointer :: ztopmn(:,:)
+   !real(r8), pointer :: ztopma(:)
+   !real(r8), pointer :: ztopm1_macmic(:)
+   real(r8), pointer :: ztopmn(:,:,:)
+   real(r8), pointer :: ztopma(:,:)
+   real(r8), pointer :: ztopm1_macmic(:,:)
+   !real(r8), pointer :: ddcp(:)
+   !real(r8), pointer :: ddcp_macmic(:)
+   !real(r8), pointer :: ddcpmn(:,:)
+   real(r8), pointer :: ddcp(:,:)
+   real(r8), pointer :: ddcp_macmic(:,:)
+   real(r8), pointer :: ddcpmn(:,:,:)
+!---ARH
 
    real(r8), pointer :: cbm1(:)
    real(r8), pointer :: cbm1_macmic(:)
@@ -2420,12 +2435,17 @@ end subroutine clubb_init_cnst
 
    logical                              :: cfllim
 
-   real(r8)                             :: mf_ztop,    mf_ztop_nadv,   &
-                                           mf_ztopm1,  mf_ztopm1_nadv, &
-                                           mf_precc_nadv, mf_snow_nadv,&
-                                           mf_L0,      mf_L0_nadv,     &
-                                           mf_ddcp,    mf_ddcp_nadv,   &
+!+++ARH
+   !real(r8)                             :: mf_ztop,    mf_ztop_nadv,   &
+   !                                        mf_ztopm1,  mf_ztopm1_nadv, &
+   real(r8)                             :: mf_precc_nadv, mf_snow_nadv,&
+                                           !mf_L0,      mf_L0_nadv,     &
+                                           !mf_ddcp,    mf_ddcp_nadv,   &
                                            mf_cbm1,    mf_cbm1_nadv
+   real(r8), dimension(clubb_mf_nup)    :: mf_ztop,    mf_ztop_nadv,   &
+                                           mf_ztopm1,  mf_ztopm1_nadv, &
+                                           mf_L0,      mf_L0_nadv,     &
+                                           mf_ddcp,    mf_ddcp_nadv
 
    real(r8), dimension(pcols,pver)      :: esat,      rh
    real(r8), dimension(pcols,pver)      :: mq,        mqsat
@@ -3304,8 +3324,8 @@ end subroutine clubb_init_cnst
         mf_cbm1        = 0._r8
         mf_cbm1_nadv   = 0._r8
 
-        if (macmic_it==1) ztopm1_macmic(i) = 0._r8
-        if (macmic_it==1) ddcp_macmic(i) = 0._r8
+        if (macmic_it==1) ztopm1_macmic(i,:) = 0._r8
+        if (macmic_it==1) ddcp_macmic(i,:) = 0._r8
         if (macmic_it==1) cbm1_macmic(i) = 0._r8
 
 !+++ARH
@@ -3345,7 +3365,7 @@ end subroutine clubb_init_cnst
 
 !+++ARH - Temporary hack - pbuf_set_field is apparently not taking?
         if (is_first_step() .and. macmic_it==1) then
-          ddcp(i) = 0._r8
+          ddcp(i,:) = 0._r8
         end if
 !---ARH
 
@@ -3405,8 +3425,16 @@ end subroutine clubb_init_cnst
              thv_ds_zm = zt2zm_api( thv_ds_zt  )
            end if
 
-           mf_ztopm1 = ztopma(i) 
-           mf_ddcp = ddcp(i)
+!+++ARH
+           !mf_ztopm1 = ztopma(i) 
+           mf_ztopm1(:) = ztopma(i,:)
+           !mf_ddcp = ddcp(i)
+           mf_ddcp(:) = ddcp(i,:)
+write(iam+1000,*) '----------------------------'
+write(iam+1000,*) 'nstep: ', get_nstep(), ' macmic_it: ', macmic_it, ' nadv: ', t
+write(iam+1000,*) 'ztopm1: ', mf_ztopm1(:)
+write(iam+1000,*) 'ddcp: ', mf_ddcp(:)
+!---ARH
            mf_cbm1 = cbm1(i)
 
            rhinv = 0._r8
@@ -3567,10 +3595,12 @@ end subroutine clubb_init_cnst
            max_cfl_nadv = MAX(max_cfl,max_cfl_nadv)
 !+++ARH
          if (t==1) then
-
-           ztop_macmic1(i,macmic_it) = mf_ztopm1
-           ddcp_macmic1(i,macmic_it) = mf_ddcp
-
+!+++ARH
+           !ztop_macmic1(i,macmic_it) = mf_ztopm1
+           ztop_macmic1(i,macmic_it) = MAXVAL(mf_ztopm1)
+           !ddcp_macmic1(i,macmic_it) = mf_ddcp
+           ddcp_macmic1(i,macmic_it) = MAXVAL(mf_ddcp)
+!---ARH
            do k=1,nlev+1
              flip(pverp-k+1,:clubb_mf_nup) = mf_upw(k,:clubb_mf_nup)
            end do
@@ -3673,9 +3703,12 @@ end subroutine clubb_init_cnst
 
          else if (t==2) then
 
-           ztop_macmic2(i,macmic_it) = mf_ztopm1
-           ddcp_macmic2(i,macmic_it) = mf_ddcp
-
+!+++ARH
+           !ztop_macmic2(i,macmic_it) = mf_ztopm1
+           ztop_macmic2(i,macmic_it) = MAXVAL(mf_ztopm1)
+           !ddcp_macmic2(i,macmic_it) = mf_ddcp
+           ddcp_macmic2(i,macmic_it) = MAXVAL(mf_ddcp)
+!---ARH
            do k=1,nlev+1
              flip(pverp-k+1,:clubb_mf_nup) = mf_upw(k,:clubb_mf_nup)
            end do
@@ -3895,8 +3928,8 @@ end subroutine clubb_init_cnst
         mf_cbm1_nadv = mf_cbm1_nadv/REAL(nadv)
 
         ! accumulate in buffer
-        ztopm1_macmic(i) = ztopm1_macmic(i) + mf_ztopm1_nadv
-        ddcp_macmic(i) = ddcp_macmic(i) + mf_ddcp_nadv
+        ztopm1_macmic(i,:) = ztopm1_macmic(i,:) + mf_ztopm1_nadv(:)
+        ddcp_macmic(i,:) = ddcp_macmic(i,:) + mf_ddcp_nadv(:)
         cbm1_macmic(i) = cbm1_macmic(i) + mf_cbm1_nadv
 
         if (macmic_it == cld_macmic_num_steps) then
@@ -3904,30 +3937,48 @@ end subroutine clubb_init_cnst
           cbm1(i) = cbm1_macmic(i)/REAL(cld_macmic_num_steps)
 
           if (clubb_mf_up_ndt == 1) then
-            ztopma(i) = ztopm1_macmic(i)/REAL(cld_macmic_num_steps)
+            ztopma(i,:) = ztopm1_macmic(i,:)/REAL(cld_macmic_num_steps)
           else
-            ztopmn(2:clubb_mf_up_ndt,i) = ztopmn(1:clubb_mf_up_ndt-1,i)
-            ztopmn(1,i) = ztopm1_macmic(i)/REAL(cld_macmic_num_steps)
-            ztopma(i) = 0._r8
+!+++ARH
+            !ztopmn(2:clubb_mf_up_ndt,i) = ztopmn(1:clubb_mf_up_ndt-1,i)
+            !ztopmn(1,i) = ztopm1_macmic(i)/REAL(cld_macmic_num_steps)
+            !ztopma(i) = 0._r8
+            !do t=1,clubb_mf_up_ndt
+            !  ztopma(i) = ztopma(i) + ztopmn(t,i)
+            !end do
+            !ztopma(i) = ztopma(i)/REAL(clubb_mf_up_ndt)
+            ztopmn(2:clubb_mf_up_ndt,i,:) = ztopmn(1:clubb_mf_up_ndt-1,i,:)
+            ztopmn(1,i,:) = ztopm1_macmic(i,:)/REAL(cld_macmic_num_steps)
+            ztopma(i,:) = 0._r8
             do t=1,clubb_mf_up_ndt
-              ztopma(i) = ztopma(i) + ztopmn(t,i)
+              ztopma(i,:) = ztopma(i,:) + ztopmn(t,i,:)
             end do
-            ztopma(i) = ztopma(i)/REAL(clubb_mf_up_ndt)
+            ztopma(i,:) = ztopma(i,:)/REAL(clubb_mf_up_ndt)
+!---ARH
           end if
 
           if (clubb_mf_cp_ndt == 1) then
-            ddcp(i) = ddcp_macmic(i)/REAL(cld_macmic_num_steps)
+            ddcp(i,:) = ddcp_macmic(i,:)/REAL(cld_macmic_num_steps)
           else
-            ddcpmn(2:clubb_mf_cp_ndt,i) = ddcpmn(1:clubb_mf_cp_ndt-1,i)
-            ddcpmn(1,i) = ddcp_macmic(i)/REAL(cld_macmic_num_steps) 
-            ddcp(i) = 0._r8
+!+++ARH
+            !ddcpmn(2:clubb_mf_cp_ndt,i) = ddcpmn(1:clubb_mf_cp_ndt-1,i)
+            !ddcpmn(1,i) = ddcp_macmic(i)/REAL(cld_macmic_num_steps) 
+            !ddcp(i) = 0._r8
+            !do t=1,clubb_mf_cp_ndt
+            !  ddcp(i) = ddcp(i) + ddcpmn(t,i)
+            !end do
+            !ddcp(i) = ddcp(i)/REAL(clubb_mf_cp_ndt)
+            ddcpmn(2:clubb_mf_cp_ndt,i,:) = ddcpmn(1:clubb_mf_cp_ndt-1,i,:)
+            ddcpmn(1,i,:) = ddcp_macmic(i,:)/REAL(cld_macmic_num_steps)
+            ddcp(i,:) = 0._r8
             do t=1,clubb_mf_cp_ndt
-              ddcp(i) = ddcp(i) + ddcpmn(t,i)
+              ddcp(i,:) = ddcp(i,:) + ddcpmn(t,i,:)
             end do
-            ddcp(i) = ddcp(i)/REAL(clubb_mf_cp_ndt)
+            ddcp(i,:) = ddcp(i,:)/REAL(clubb_mf_cp_ndt)
+!---ARH
           end if
 
-          ddcp(i) = clubb_mf_ddalph*ddcp(i)
+          ddcp(i,:) = clubb_mf_ddalph*ddcp(i,:)
 
         end if
  
@@ -4120,12 +4171,12 @@ end subroutine clubb_init_cnst
       enddo
 
       if (do_clubb_mf) then
-        if (mf_ztop_nadv == 0._r8) mf_ztop_nadv = fillvalue
-        if (mf_L0_nadv == 0._r8) mf_L0_nadv = fillvalue
-        mf_ztop_output(i) = ztopma(i) !mf_ztop_nadv
-        mf_L0_output(i)   = mf_L0_nadv
+        !if (mf_ztop_nadv == 0._r8) mf_ztop_nadv = fillvalue
+        !if (mf_L0_nadv == 0._r8) mf_L0_nadv = fillvalue
+        mf_ztop_output(i) = MAXVAL(ztopma(i,:)) !mf_ztop_nadv
+        mf_L0_output(i)   = MAXVAL(mf_L0_nadv)
         mf_cfl_output(i)  = max_cfl_nadv
-        mf_ddcp_output(i) = ddcp(i) !mf_ddcp_nadv !ddcp(i)
+        mf_ddcp_output(i) = MAXVAL(ddcp(i,:)) !mf_ddcp_nadv !ddcp(i)
         do k=1,clubb_mf_nup
           mf_upa_output(i,pverp*(k-1)+1:pverp*k)   = mf_upa_flip(i,:pverp,k)
           mf_upw_output(i,pverp*(k-1)+1:pverp*k)   = mf_upw_flip(i,:pverp,k)

--- a/src/physics/cam/clubb_mf.F90
+++ b/src/physics/cam/clubb_mf.F90
@@ -61,6 +61,9 @@ module clubb_mf
   logical, protected :: do_clubb_mf_diag = .false.
   logical, protected :: do_clubb_mf_rad = .false.
   logical, protected :: do_clubb_mf_coldpool = .false.
+  logical, protected :: do_clubb_mf_coldpool_init = .false.
+  logical, protected :: do_clubb_mf_coldpool_perplume = .false.
+  logical, protected :: do_clubb_mf_lscale_perplume = .false.
   ! +++ MDF 
   ! Note: No idea if this should be 'protected' or not 
   logical, protected :: do_clubb_mf_patchInit = .false.
@@ -95,7 +98,8 @@ module clubb_mf
                            do_clubb_mf_patchInit, &
                            ! --- MDF
                            clubb_mf_fdd, do_clubb_mf_coldpool, clubb_mf_ddalph, clubb_mf_ddbeta, clubb_mf_pwfac, do_clubb_mf_ustar, &
-                           clubb_mf_ddexp, do_clubb_mf_mixd, clubb_mf_up_ndt, clubb_mf_cp_ndt
+                           clubb_mf_ddexp, do_clubb_mf_mixd, clubb_mf_up_ndt, clubb_mf_cp_ndt, &
+                           do_clubb_mf_coldpool_init, do_clubb_mf_coldpool_perplume, do_clubb_mf_lscale_perplume
 
     if (masterproc) then
       open( newunit=iunit, file=trim(nlfile), status='old' )
@@ -157,6 +161,12 @@ module clubb_mf
     if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: clubb_mf_ddexp")
     call mpi_bcast(do_clubb_mf_mixd, 1, mpi_logical, mstrid, mpicom, ierr)
     if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: do_clubb_mf_mixd")
+    call mpi_bcast(do_clubb_mf_coldpool_init, 1, mpi_logical, mstrid, mpicom, ierr)
+    if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: do_clubb_mf_coldpool_init")
+    call mpi_bcast(do_clubb_mf_coldpool_perplume, 1, mpi_logical, mstrid, mpicom, ierr)
+    if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: do_clubb_mf_coldpool_perplume")
+    call mpi_bcast(do_clubb_mf_lscale_perplume, 1, mpi_logical, mstrid, mpicom, ierr)
+    if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: do_clubb_mf_lscae_perplume")
 
     if ((.not. do_clubb_mf) .and. do_clubb_mf_diag ) then
        call endrun('clubb_mf_readnl: Error - cannot turn on do_clubb_mf_diag without also turning on do_clubb_mf')
@@ -280,7 +290,11 @@ module clubb_mf
                                                 patchLH, patchFV, patchTHS 
      !--- MDF 
 
-     real(r8), intent(inout)             :: ztopm1,ddcp,cbm1
+!+++ARH
+     !real(r8), intent(inout)             :: ztopm1,ddcp,cbm1
+     real(r8), intent(inout)             :: cbm1
+     real(r8),dimension(clubb_mf_nup),intent(inout) :: ztopm1, ddcp
+!---ARH
 
      real(r8),dimension(nz,clubb_mf_nup), intent(out) :: upa,     & ! momentum grid
                                                          upw,     & ! momentum grid
@@ -337,8 +351,7 @@ module clubb_mf
                                             sqt,     sthl,           & ! thermodynamic grid 
                                             precc
 
-     real(r8), intent(out)               :: ztop,    dynamic_L0,  &
-                                            mcape   
+     real(r8),dimension(clubb_mf_nup), intent(out) :: ztop, dynamic_L0, mcape
      ! =============================================================================== !
      ! INTERNAL VARIABLES
      !
@@ -373,8 +386,8 @@ module clubb_mf
      ! other variables
      integer                              :: k,i,kstart,ddtop,kcb
      integer,  dimension(clubb_mf_nup)    :: ddbot,kcbarr
-     real(r8), dimension(clubb_mf_nup)    :: zcb
-     real(r8)                             :: zcb_unset,       cpfac,   &
+     real(r8), dimension(clubb_mf_nup)    :: zcb, cpfac
+     real(r8)                             :: zcb_unset,                &
                                              wthv,   ddint,   iddcp,   &
                                              wstar,  qstar,   thvstar, & 
                                              sigmaw, sigmaqt, sigmathv,&
@@ -659,8 +672,6 @@ module clubb_mf
 
 
 ! +++ MDF: Big hammer of code mods
-    ! Defining this here to avoid any errors
-    !cpfac = 1._r8
  
     if (do_clubb_mf_patchInit .and. landfracFromSfc==1.0_r8 .and. (.not. is_first_step())) then
 
@@ -776,8 +787,12 @@ module clubb_mf
             ! --------------------------------------------------------- !
             ! Compute cold pool feedback parameter                      ! 
             ! --------------------------------------------------------- !
-            cpfac = 1._r8
-            if (do_clubb_mf_coldpool) cpfac = min( (max(ddcp/wstar,1._r8))**clubb_mf_ddbeta, max_cpfac ) 
+            cpfac(:) = 1._r8
+            if (do_clubb_mf_coldpool) then 
+              do i=1,clubb_mf_nup
+                cpfac(i) = min( (max(ddcp(i)/wstar,1._r8))**clubb_mf_ddbeta, max_cpfac ) 
+              end do
+            end if
 
             ! --------------------------------------------------------- !
             ! Construct tri-variate PDF at the surface from wstar       ! 
@@ -800,16 +815,23 @@ module clubb_mf
                qstar   = thisPatchLH/thisPatchFV
                thvstar = wthv/thisPatchFV
 
-               sigmaw   = alphw * wstar * cpfac
-               sigmaqt  = alphqt * abs(qstar) * cpfac
-               sigmathv = alphthv * abs(thvstar) * cpfac
-
-               wmin = sigmaw * pwmin
-               wmax = sigmaw * pwmax
-
-               pNorm = 1._r8
-
                do i=patchPlumesTotal+1, patchPlumesTotal+patchPlumes
+
+                   if (do_clubb_mf_coldpool_init) then
+                     sigmaw   = alphw * wstar * cpfac(i)
+                     sigmaqt  = alphqt * abs(qstar) * cpfac(i)
+                     sigmathv = alphthv * abs(thvstar) * cpfac(i)
+                   else
+                     sigmaw   = alphw * wstar
+                     sigmaqt  = alphqt * abs(qstar)
+                     sigmathv = alphthv * abs(thvstar)
+                   end if
+
+                   wmin = sigmaw * pwmin
+                   wmax = sigmaw * pwmax
+
+                   pNorm = 1._r8
+
                    !write(iulog,*)'MDF: initiate plume i over patch p',i,p
                    !write(iulog,*)'MDF: patchPlumes = ',patchPlumes
                    !write(iulog,*)'MDF: pNorm = ',pNorm
@@ -882,14 +904,17 @@ module clubb_mf
           ! --------------------------------------------------------- !
           ! Compute cold pool feedback parameter                      ! 
           ! --------------------------------------------------------- !
-          cpfac = 1._r8
-          if (do_clubb_mf_coldpool) cpfac = min( (max(ddcp/wstar,1._r8))**clubb_mf_ddbeta, max_cpfac ) 
+          cpfac(:) = 1._r8
+          if (do_clubb_mf_coldpool) then
+            do i=1,clubb_mf_nup
+              cpfac(i) = min( (max(ddcp(i)/wstar,1._r8))**clubb_mf_ddbeta, max_cpfac )
+            end do
+          end if
 
           ! --------------------------------------------------------- !
           ! Construct tri-variate PDF at the surface from wstar       ! 
           ! and initialize plume thv, qt, w                           !
           ! --------------------------------------------------------- !
-
           if (do_clubb_mf_ustar) then
              qstar   = wqt / max(wstarmin,ustar)
              thvstar = wthv / max(wstarmin,ustar)
@@ -898,24 +923,31 @@ module clubb_mf
              thvstar = wthv / wstar
           end if
 
-          sigmaw   = alphw * wstar * cpfac
-          sigmaqt  = alphqt * abs(qstar) * cpfac
-          sigmathv = alphthv * abs(thvstar) * cpfac
-
-          wmin = sigmaw * pwmin
-          wmax = sigmaw * pwmax
-
-          ! More debug options
-          !write(iulog,*)'MDF (debug): wthv = ',wthv
-          !write(iulog,*)'MDF (debug): wthl = ',wthl
-          !write(iulog,*)'MDF (debug): wqt = ',wqt
-          !write(iulog,*)'MDF (debug): wstar = ',wstar
-          !write(iulog,*)'MDF (debug): qstar   = ',qstar
-          !write(iulog,*)'MDF (debug): thvstar = ',thvstar
-          !write(iulog,*)'MDF (debug): sigmaqt = ',sigmaqt
-          !write(iulog,*)'MDF (debug): sigmathv = ',sigmathv
-
           do i=1,clubb_mf_nup
+
+             if (do_clubb_mf_coldpool_init) then
+               sigmaw   = alphw * wstar * cpfac(i)
+               sigmaqt  = alphqt * abs(qstar) * cpfac(i)
+               sigmathv = alphthv * abs(thvstar) * cpfac(i)
+             else
+               sigmaw   = alphw * wstar
+               sigmaqt  = alphqt * abs(qstar)
+               sigmathv = alphthv * abs(thvstar)
+             end if
+
+            wmin = sigmaw * pwmin
+            wmax = sigmaw * pwmax
+
+            ! More debug options
+            !write(iulog,*)'MDF (debug): wthv = ',wthv
+            !write(iulog,*)'MDF (debug): wthl = ',wthl
+            !write(iulog,*)'MDF (debug): wqt = ',wqt
+            !write(iulog,*)'MDF (debug): wstar = ',wstar
+            !write(iulog,*)'MDF (debug): qstar   = ',qstar
+            !write(iulog,*)'MDF (debug): thvstar = ',thvstar
+            !write(iulog,*)'MDF (debug): sigmaqt = ',sigmaqt
+            !write(iulog,*)'MDF (debug): sigmathv = ',sigmathv
+
             wlv = wmin + (wmax-wmin) / (real(clubb_mf_nup,r8)) * (real(i-1, r8))
             wtv = wmin + (wmax-wmin) / (real(clubb_mf_nup,r8)) * real(i,r8)
 
@@ -983,32 +1015,36 @@ module clubb_mf
          end if
        end do
 
-       ! --------------------------------------------------------- !
-       ! Calculate ztop and dynamic_L based on value of namelist   ! 
-       ! --------------------------------------------------------- !
-       call get_Lscale (nz, zm, tke, wpthlp_env, dzt, iexner_zm, iexner_zt, p_zm, qt, thv, thl, th, &
-                        wmax, wmin, sigmaw, sigmaqt, sigmathv, cwqt, cwthv, zcb_unset, wa, wb,  &
-                        do_condensation, qv, p_zt, zt, tpert, pblh, convh, rhinv, ztopm1, dynamic_L0, ztop, mcape)
+       do i=1,clubb_mf_nup
+         ! --------------------------------------------------------- !
+         ! Calculate ztop and dynamic_L based on value of namelist   ! 
+         ! --------------------------------------------------------- !
+         call get_Lscale (nz, zm, tke, wpthlp_env, dzt, iexner_zm, iexner_zt, p_zm, qt, thv, thl, th, &
+                          wmax, wmin, sigmaw, sigmaqt, sigmathv, cwqt, cwthv, zcb_unset, wa, wb,  &
+                          do_condensation, qv, p_zt, zt, tpert, pblh, convh, rhinv, ztopm1(i), dynamic_L0(i), ztop(i), mcape(i))
 
-       ! cold pool feedback on the entrainmnet length scale
-       dynamic_L0 = dynamic_L0 * cpfac
+         ! cold pool feedback on the entrainmnet length scale
+         dynamic_L0(i) = dynamic_L0(i) * cpfac(i)
 
-       ! limit max/min
-       dynamic_L0 = max(min_L0,dynamic_L0)
-       dynamic_L0 = min(clubb_mf_max_L0,dynamic_L0)
+         ! limit max/min
+         dynamic_L0(i) = max(min_L0,dynamic_L0(i))
+         dynamic_L0(i) = min(clubb_mf_max_L0,dynamic_L0(i))
 
-       ! --------------------------------------------------------- !
-       ! Stochastic entrainmnet calculation                        ! 
-       ! From Suselj et al 2019, after Romps and Kuang 2010        !
-       ! (ideally we wouldn't fill the entire arrray w/ the RNG,   !
-       ! but the RNG doesn't work properly when it operates on     !
-       ! the entire array. I'm not sure why this is happening.)    !
-       ! --------------------------------------------------------- !
-       do k=1,nz-1
-         ! get entrainment coefficient, dz/L0
-         entf(k,:) = dzt(k) / dynamic_L0
+         ! --------------------------------------------------------- !
+         ! Stochastic entrainmnet calculation                        ! 
+         ! From Suselj et al 2019, after Romps and Kuang 2010        !
+         ! (ideally we wouldn't fill the entire arrray w/ the RNG,   !
+         ! but the RNG doesn't work properly when it operates on     !
+         ! the entire array. I'm not sure why this is happening.)    !
+         ! --------------------------------------------------------- !
+         do k=1,nz-1
+           ! get entrainment coefficient, dz/L0
+           entf(k,i) = dzt(k) / dynamic_L0(i)
+         end do
+         !
        end do
-
+!---ARH
+  
        ! get poisson, P(dz/L0)
        call poisson( nz, clubb_mf_nup, entf, enti, u(2:5))
 
@@ -1073,7 +1109,7 @@ module clubb_mf
                                     thvn, qcn, thn, qln, qin, qsn, lmixn)
 
                ! critical stopping distance
-               cridis = rle*ztopm1
+               cridis = rle*ztopm1(i)
 
                ! ----------------------------------------------------------------- !
                ! Case 1 : When both cumulus and env. are unsaturated or saturated. !
@@ -1147,7 +1183,7 @@ module clubb_mf
              ! TKE enhanced entrainment                                  ! 
              ! switches off when dynamic_L0 > max_L0                     !
              ! --------------------------------------------------------- !
-             if (dynamic_L0 >= clubb_mf_max_L0) then
+             if (dynamic_L0(i) >= clubb_mf_max_L0) then
                eturb = 1._r8
              else
                eturb = (1._r8 + clubb_mf_alphturb*sqrt(tke(k))/upw(k,i))
@@ -1310,7 +1346,7 @@ module clubb_mf
                entn = fixent_ent
              else
                ! use deterministic mean entrainment
-               entn = clubb_mf_ent0/dynamic_L0
+               entn = clubb_mf_ent0/dynamic_L0(i)
              end if
 
              ! downdraft qsat
@@ -1595,19 +1631,26 @@ module clubb_mf
        ! --------------------------------------------------------- !
        ! ztopm1 calculation                                        ! 
        ! --------------------------------------------------------- !
+!+++ARH
+     do i=1,clubb_mf_nup
        do k=1,nz
-         ! retrun if no convection at k=2
+         ! return if no convection at k=2
          if (k == 2 .and. ac(k) == 0._r8) then
            sqt(k) = 0_r8
            sthl(k) = 0._r8
-           ztopm1 = zm(1)
-           ddcp = 0._r8
+           ztopm1(:) = zm(1)
+           ddcp(:) = 0._r8
            return
          end if
          ! height of the plume ensemble
-         if (ac(k) > 0._r8) ztopm1 = zm(k)
+         if (do_clubb_mf_lscale_perplume) then
+           if ((upa(k,i)+dna(k,i)) > 0._r8) ztopm1(i) = zm(k)
+         else
+           if (ac(k) > 0._r8) ztopm1(1:clubb_mf_nup) = zm(k)
+         end if
        end do
-
+    end do
+!---ARH
        ! --------------------------------------------------------- !
        ! cloud base / mixing depth calculation                                        ! 
        ! --------------------------------------------------------- !
@@ -1640,47 +1683,51 @@ module clubb_mf
        ! bulk downdraft velocity for coldpool parameterization     ! 
        ! --------------------------------------------------------- !
 !+++ARH
-       ! reset ddcp
-       ddcp = 0._r8
-       do i=1,clubb_mf_nup
-         ! find cloud base
-         kcb = 0
-         do k=1,nz
-           if (upqc(k,i) > 0._r8) then
-             kcb = k
-             exit
-           end if
-         end do
- 
-         ! reset iddcp
-         iddcp = 0._r8
-         if (kcb == 0) then
-           continue
-         else if (kcb == 1) then
-           iddcp = iddcp + dna(k,i)*dnw(k,i)
-           continue
-         else
-           ddint = 0._r8
-           do k=1,kcb-1
-             ddint = ddint + dna(k,i)*dnw(k,i)*dzt(k+1)
-           end do
-           iddcp = iddcp + -1._r8*ddint/zm(kcb)
-         end if
-         ddcp = ddcp + iddcp 
-         !
-       end do
-
-
-!       ! use single level for cold pool param.
 !       ! reset ddcp
 !       ddcp = 0._r8
 !       do i=1,clubb_mf_nup
-!         if (ddbot(i) == 0) then
+!         ! find cloud base
+!         kcb = 0
+!         do k=1,nz
+!           if (upqc(k,i) > 0._r8) then
+!             kcb = k
+!             exit
+!           end if
+!         end do
+! 
+!         ! reset iddcp
+!         iddcp = 0._r8
+!         if (kcb == 0) then
+!           continue
+!         else if (kcb == 1) then
+!           iddcp = iddcp + dna(k,i)*dnw(k,i)
 !           continue
 !         else
-!           ddcp = ddcp + -1._r8*dna(ddbot(i)+1,i)*dnw(ddbot(i)+1,i)
+!           ddint = 0._r8
+!           do k=1,kcb-1
+!             ddint = ddint + dna(k,i)*dnw(k,i)*dzt(k+1)
+!           end do
+!           iddcp = iddcp + -1._r8*ddint/zm(kcb)
 !         end if
+!         ddcp = ddcp + iddcp 
+!         !
 !       end do
+
+
+       ! use single level for cold pool param.
+       ! reset ddcp
+       ddcp(:) = 0._r8
+       do i=1,clubb_mf_nup
+         if (ddbot(i) == 0) then
+           continue
+         else
+           if (do_clubb_mf_coldpool_perplume) then
+             ddcp(i) = -1._r8*dnw(ddbot(i)+1,i)
+           else
+             ddcp(:) = ddcp(:) + -1._r8*dna(ddbot(i)+1,i)*dnw(ddbot(i)+1,i)
+           end if
+         end if
+       end do
 !---ARH
 
        ! --------------------------------------------------------- !
@@ -1762,8 +1809,8 @@ module clubb_mf
        ! --- MDF 
 
      else
-       ddcp = 0._r8
-       ztopm1 = zm(1)
+       ddcp(:) = 0._r8
+       ztopm1(:) = zm(1)
      end if  ! ( wthv > 0.0 )
 
   end subroutine integrate_mf

--- a/src/physics/cam/clubb_mf.F90
+++ b/src/physics/cam/clubb_mf.F90
@@ -56,6 +56,7 @@ module clubb_mf
   real(r8) :: clubb_mf_ddexp   = 0._r8
   integer  :: clubb_mf_up_ndt  = 1
   integer  :: clubb_mf_cp_ndt  = 1
+  integer  :: clubb_mf_kseed   = 1
   integer, protected :: clubb_mf_nup     = 0
   logical, protected :: do_clubb_mf = .false.
   logical, protected :: do_clubb_mf_diag = .false.
@@ -99,7 +100,7 @@ module clubb_mf
                            ! --- MDF
                            clubb_mf_fdd, do_clubb_mf_coldpool, clubb_mf_ddalph, clubb_mf_ddbeta, clubb_mf_pwfac, do_clubb_mf_ustar, &
                            clubb_mf_ddexp, do_clubb_mf_mixd, clubb_mf_up_ndt, clubb_mf_cp_ndt, &
-                           do_clubb_mf_coldpool_init, do_clubb_mf_coldpool_perplume, do_clubb_mf_lscale_perplume
+                           do_clubb_mf_coldpool_init, do_clubb_mf_coldpool_perplume, do_clubb_mf_lscale_perplume, clubb_mf_kseed
 
     if (masterproc) then
       open( newunit=iunit, file=trim(nlfile), status='old' )
@@ -155,6 +156,8 @@ module clubb_mf
     if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: clubb_mf_up_ndt")
     call mpi_bcast(clubb_mf_cp_ndt, 1, mpi_integer, mstrid, mpicom, ierr)
     if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: clubb_mf_cp_ndt")
+    call mpi_bcast(clubb_mf_kseed, 1, mpi_integer, mstrid, mpicom, ierr)
+    if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: clubb_mf_kseed")
     call mpi_bcast(do_clubb_mf_ustar, 1, mpi_logical, mstrid, mpicom, ierr)
     if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: do_clubb_mf_ustar")
     call mpi_bcast(clubb_mf_ddexp,  1, mpi_real8,   mstrid, mpicom, ierr)
@@ -518,6 +521,9 @@ module clubb_mf
      !
      ! limiter on cold pool effects
      real(r8),parameter                   :: max_cpfac = 5._r8
+     !
+     ! max limiter on cold pool init effects
+     real(r8),parameter                   :: max_cpinit = 0.5_r8
 
      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
      !!!!!!!!!!!!!!!!!!!!!! BEGIN CODE !!!!!!!!!!!!!!!!!!!!!!!
@@ -815,9 +821,9 @@ module clubb_mf
                do i=patchPlumesTotal+1, patchPlumesTotal+patchPlumes
 
                    if (do_clubb_mf_coldpool_init) then
-                     sigmaw   = alphw * wstar * cpfac(i)
-                     sigmaqt  = alphqt * abs(qstar) * cpfac(i)
-                     sigmathv = alphthv * abs(thvstar) * cpfac(i)
+                     sigmaw   = alphw * wstar * (1._r8 + max_cpinit*cpfac(i)/max_cpfac)
+                     sigmaqt  = alphqt * abs(qstar) * (1._r8 + max_cpinit*cpfac(i)/max_cpfac)
+                     sigmathv = alphthv * abs(thvstar) * (1._r8 + max_cpinit*cpfac(i)/max_cpfac)
                    else
                      sigmaw   = alphw * wstar
                      sigmaqt  = alphqt * abs(qstar)
@@ -923,9 +929,9 @@ module clubb_mf
           do i=1,clubb_mf_nup
 
              if (do_clubb_mf_coldpool_init) then
-               sigmaw   = alphw * wstar * cpfac(i)
-               sigmaqt  = alphqt * abs(qstar) * cpfac(i)
-               sigmathv = alphthv * abs(thvstar) * cpfac(i)
+               sigmaw   = alphw * wstar * (1._r8 + max_cpinit*cpfac(i)/max_cpfac)
+               sigmaqt  = alphqt * abs(qstar) * (1._r8 + max_cpinit*cpfac(i)/max_cpfac)
+               sigmathv = alphthv * abs(thvstar) * (1._r8 + max_cpinit*cpfac(i)/max_cpfac)
              else
                sigmaw   = alphw * wstar
                sigmaqt  = alphqt * abs(qstar)
@@ -1043,7 +1049,8 @@ module clubb_mf
 !---ARH
   
        ! get poisson, P(dz/L0)
-       call poisson( nz, clubb_mf_nup, entf, enti, u(2:5))
+       !call poisson( nz, clubb_mf_nup, entf, enti, u(2:5))
+       call poisson( nz, clubb_mf_nup, entf, enti, u(clubb_mf_kseed+1:clubb_mf_kseed+4))
 
        ! --------------------------------------------------------- !
        ! Main upward sweep to compute updraft properties           ! 

--- a/src/physics/cam/clubb_mf.F90
+++ b/src/physics/cam/clubb_mf.F90
@@ -290,11 +290,8 @@ module clubb_mf
                                                 patchLH, patchFV, patchTHS 
      !--- MDF 
 
-!+++ARH
-     !real(r8), intent(inout)             :: ztopm1,ddcp,cbm1
      real(r8), intent(inout)             :: cbm1
      real(r8),dimension(clubb_mf_nup),intent(inout) :: ztopm1, ddcp
-!---ARH
 
      real(r8),dimension(nz,clubb_mf_nup), intent(out) :: upa,     & ! momentum grid
                                                          upw,     & ! momentum grid


### PR DESCRIPTION
This PR adds plume level entrainment feedbacks to @megandevlan clasp.mf branch. The reason we are not pushing this onto the main clubb.mf branch is because it's currently frozen as we are in the processes of merging it up to the head of ESCOMP/cam_development. Plus, the motivation for these enhancements was to create greater discrimination of the sub-ensembles for each land patch, to favor deeper plumes in the patches conducive to deeper plumes, and favor shallower plumes for patches conducive to shallow plumes. These enhancements are controlled by the addition of three namelists:

```
do_clubb_mf_lscale_perplume
```

When true, and using the ```clubb_mf_Lopt```=6 option, it will set the entrainment length scale ```dynamic_L0``` for each plume member to be proportional to the height of that particular plume averaged over the prior ```clubb_mf_up_ndt``` number of time-steps. The proportionality constants ```clubb_mf_a0``` and ```clubb_mf_b0``` will need to be adjusted from our usual Lopt=6 values (a0=2 (0.07), b0=0.5 (1.0)). The values in general need to be increased because conventional Lopt=6 took the height of the tallest plume at prior time-steps to set the entrainment length scale *for the entire ensemble*.

```
do_clubb_mf_coldpool_perplume
```

When true, it will take the downdraft speed of each ensemble member to set a cold pool strength for each member. Like the conventional approach, downdraft speeds are multiplied by ```clubb_mf_ddalph``` to get the cold pool strength. However, the conventional implementation takes the *ensemble mean* downdraft speed (sum of a_i*wdn_i), whereas this new method does not use area weighting; the downdraft speed alone is the cold pool strength. Therefore, ``clubb_mf_ddalph```=1, or thereabouts, should be used with this new method, whereas the conventional method uses a value of 500, or thereabouts. Ill note that I'm less confident in making this a plume level feedback than the lscale_perplume mods. But nonetheless we can experiments with it. 

```
do_clubb_mf_coldpool_init
```

This namelist is related to an issue raised at the CLUBB+MF annual mtg, where Marcin noticed that the initialized plume velocities in LBA were much larger than in LES. This is likely because the coldpool parameter, in addition to increasing the entrainment length scale, also proportionally widened the tri-variate (qt,thv,w) pdf used to initialize the plume ensemble. I've set this to false as the default. That is, to reproduce our prior coldpool feedback runs, this needs to be set to true in user_nl_cam. 

@rls347 @mikaelwitte @mchinita 